### PR TITLE
fix: replace int data type

### DIFF
--- a/boltz/api.go
+++ b/boltz/api.go
@@ -21,10 +21,10 @@ type GetVersionResponse struct {
 }
 
 type symbolMinerFees struct {
-	Normal  int `json:"normal"`
+	Normal  uint64 `json:"normal"`
 	Reverse struct {
-		Lockup int `json:"lockup"`
-		Claim  int `json:"claim"`
+		Lockup uint64 `json:"lockup"`
+		Claim  uint64 `json:"claim"`
 	} `json:"reverse"`
 }
 
@@ -33,8 +33,8 @@ type GetPairsResponse struct {
 	Pairs    map[string]struct {
 		Rate   float32 `json:"rate"`
 		Limits struct {
-			Maximal int `json:"maximal"`
-			Minimal int `json:"minimal"`
+			Maximal uint64 `json:"maximal"`
+			Minimal uint64 `json:"minimal"`
 		} `json:"limits"`
 		Fees struct {
 			Percentage float32 `json:"percentage"`
@@ -61,7 +61,7 @@ type SwapStatusResponse struct {
 	Status  string `json:"status"`
 	Channel struct {
 		FundingTransactionId   string `json:"fundingTransactionId"`
-		FundingTransactionVout int    `json:"fundingTransactionVout"`
+		FundingTransactionVout uint32 `json:"fundingTransactionVout"`
 	} `json:"channel"`
 	Transaction struct {
 		Id  string `json:"id"`
@@ -109,8 +109,8 @@ type CreateSwapResponse struct {
 	Address            string `json:"address"`
 	RedeemScript       string `json:"redeemScript"`
 	AcceptZeroConf     bool   `json:"acceptZeroConf"`
-	ExpectedAmount     int    `json:"expectedAmount"`
-	TimeoutBlockHeight int    `json:"timeoutBlockHeight"`
+	ExpectedAmount     uint64 `json:"expectedAmount"`
+	TimeoutBlockHeight uint32 `json:"timeoutBlockHeight"`
 
 	Error string `json:"error"`
 }
@@ -120,9 +120,9 @@ type SwapRatesRequest struct {
 }
 
 type SwapRatesResponse struct {
-	OnchainAmount int `json:"onchainAmount"`
+	OnchainAmount uint64 `json:"onchainAmount"`
 	SubmarineSwap struct {
-		InvoiceAmount int `json:"invoiceAmount"`
+		InvoiceAmount uint64 `json:"invoiceAmount"`
 	} `json:"submarineSwap"`
 
 	Error string `json:"error"`
@@ -141,7 +141,7 @@ type CreateReverseSwapRequest struct {
 	Type           string `json:"type"`
 	PairId         string `json:"pairId"`
 	OrderSide      string `json:"orderSide"`
-	InvoiceAmount  int    `json:"invoiceAmount"`
+	InvoiceAmount  uint64 `json:"invoiceAmount"`
 	PreimageHash   string `json:"preimageHash"`
 	ClaimPublicKey string `json:"claimPublicKey"`
 }
@@ -166,10 +166,10 @@ type CreateChannelCreationRequest struct {
 type CreateReverseSwapResponse struct {
 	Id                 string `json:"id"`
 	Invoice            string `json:"invoice"`
-	OnchainAmount      int    `json:"onchainAmount"`
+	OnchainAmount      uint64 `json:"onchainAmount"`
 	RedeemScript       string `json:"redeemScript"`
 	LockupAddress      string `json:"lockupAddress"`
-	TimeoutBlockHeight int    `json:"TimeoutBlockHeight"`
+	TimeoutBlockHeight uint32 `json:"TimeoutBlockHeight"`
 
 	Error string `json:"error"`
 }
@@ -192,8 +192,8 @@ func (boltz *Boltz) GetPairs() (*GetPairsResponse, error) {
 	return &response, err
 }
 
-func (boltz *Boltz) GetFeeEstimation() (*map[string]int, error) {
-	var response map[string]int
+func (boltz *Boltz) GetFeeEstimation() (*map[string]uint64, error) {
+	var response map[string]uint64
 	err := boltz.sendGetRequest("/getfeeestimation", &response)
 
 	return &response, err

--- a/boltz/scripts.go
+++ b/boltz/scripts.go
@@ -11,7 +11,7 @@ import (
 
 var invalidRedeemScript = errors.New("invalid redeem script")
 
-func CheckSwapScript(redeemScript, preimageHash []byte, refundKey *btcec.PrivateKey, timeoutBlockHeight int) error {
+func CheckSwapScript(redeemScript, preimageHash []byte, refundKey *btcec.PrivateKey, timeoutBlockHeight uint32) error {
 	disassembledScript, err := txscript.DisasmString(redeemScript)
 
 	if err != nil {
@@ -40,7 +40,7 @@ func CheckSwapScript(redeemScript, preimageHash []byte, refundKey *btcec.Private
 	return nil
 }
 
-func CheckReverseSwapScript(redeemScript, preimageHash []byte, claimKey *btcec.PrivateKey, timeoutBlockHeight int) error {
+func CheckReverseSwapScript(redeemScript, preimageHash []byte, claimKey *btcec.PrivateKey, timeoutBlockHeight uint32) error {
 	disassembledScript, err := txscript.DisasmString(redeemScript)
 
 	if err != nil {
@@ -73,7 +73,7 @@ func CheckReverseSwapScript(redeemScript, preimageHash []byte, claimKey *btcec.P
 	return nil
 }
 
-func formatHeight(height int) string {
+func formatHeight(height uint32) string {
 	test, _ := txscript.NewScriptBuilder().AddInt64(int64(height)).Script()
 	return hex.EncodeToString(test[1:])
 }

--- a/boltz/scripts_test.go
+++ b/boltz/scripts_test.go
@@ -15,7 +15,7 @@ func TestCheckSwapScript(t *testing.T) {
 	key, _ := hex.DecodeString("88c4ac1e6d099ea63eda4a0ae4863420dbca9aa1bce536aa63d46db28c7b780e")
 	refundKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), key)
 
-	timeoutBlockHeight := 248
+	var timeoutBlockHeight uint32 = 248
 
 	assert.Nil(t, CheckSwapScript(redeemScript, preimageHash, refundKey, timeoutBlockHeight))
 
@@ -34,7 +34,7 @@ func TestCheckReverseSwapScript(t *testing.T) {
 	key, _ := hex.DecodeString("dddc90e33843662631fb8c3833c4743ffd8f00a94715735633bf178e62eb291c")
 	claimKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), key)
 
-	timeoutBlockHeight := 248
+	var timeoutBlockHeight uint32 = 248
 
 	assert.Nil(t, CheckReverseSwapScript(redeemScript, preimageHash, claimKey, timeoutBlockHeight))
 

--- a/database/channel.go
+++ b/database/channel.go
@@ -9,19 +9,19 @@ import (
 type ChannelCreation struct {
 	SwapId                 string
 	Status                 boltz.ChannelState
-	InboundLiquidity       int
+	InboundLiquidity       uint32
 	Private                bool
 	FundingTransactionId   string
-	FundingTransactionVout int
+	FundingTransactionVout uint32
 }
 
 type ChannelCreationSerialized struct {
 	SwapId                 string
 	Status                 string
-	InboundLiquidity       int
+	InboundLiquidity       uint32
 	Private                bool
 	FundingTransactionId   string
-	FundingTransactionVout int
+	FundingTransactionVout uint32
 }
 
 func (channelCreation *ChannelCreation) Serialize() ChannelCreationSerialized {
@@ -103,7 +103,7 @@ func (database *Database) CreateChannelCreation(channelCreation ChannelCreation)
 	return statement.Close()
 }
 
-func (database *Database) SetChannelFunding(channelCreation *ChannelCreation, fundingTransactionId string, fundingTransactionVout int) error {
+func (database *Database) SetChannelFunding(channelCreation *ChannelCreation, fundingTransactionId string, fundingTransactionVout uint32) error {
 	channelCreation.Status = boltz.ChannelAccepted
 	channelCreation.FundingTransactionId = fundingTransactionId
 	channelCreation.FundingTransactionVout = fundingTransactionVout

--- a/database/reverse.go
+++ b/database/reverse.go
@@ -21,8 +21,8 @@ type ReverseSwap struct {
 	RedeemScript        []byte
 	Invoice             string
 	ClaimAddress        string
-	OnchainAmount       int
-	TimeoutBlockHeight  int
+	OnchainAmount       uint64
+	TimeoutBlockHeight  uint32
 	LockupTransactionId string
 	ClaimTransactionId  string
 }
@@ -38,8 +38,8 @@ type ReverseSwapSerialized struct {
 	RedeemScript        string
 	Invoice             string
 	ClaimAddress        string
-	OnchainAmount       int
-	TimeoutBlockHeight  int
+	OnchainAmount       uint64
+	TimeoutBlockHeight  uint32
 	LockupTransactionId string
 	ClaimTransactionId  string
 }

--- a/database/swap.go
+++ b/database/swap.go
@@ -20,8 +20,8 @@ type Swap struct {
 	RedeemScript        []byte
 	Invoice             string
 	Address             string
-	ExpectedAmount      int
-	TimoutBlockHeight   int
+	ExpectedAmount      uint64
+	TimoutBlockHeight   uint32
 	LockupTransactionId string
 	RefundTransactionId string
 }
@@ -36,8 +36,8 @@ type SwapSerialized struct {
 	RedeemScript        string
 	Invoice             string
 	Address             string
-	ExpectedAmount      int
-	TimeoutBlockHeight  int
+	ExpectedAmount      uint64
+	TimeoutBlockHeight  uint32
 	LockupTransactionId string
 	RefundTransactionId string
 }
@@ -177,7 +177,7 @@ func (database *Database) QueryPendingSwaps() ([]Swap, error) {
 }
 
 func (database *Database) QueryRefundableSwaps(currentBlockHeight uint32) ([]Swap, error) {
-	return database.querySwaps("SELECT * FROM swaps WHERE (state = '" + strconv.Itoa(int(boltzrpc.SwapState_PENDING)) + "' OR state = '"+ strconv.Itoa(int(boltzrpc.SwapState_SERVER_ERROR)) + "') AND timeoutBlockHeight <= " + strconv.FormatUint(uint64(currentBlockHeight), 10))
+	return database.querySwaps("SELECT * FROM swaps WHERE (state = '" + strconv.Itoa(int(boltzrpc.SwapState_PENDING)) + "' OR state = '" + strconv.Itoa(int(boltzrpc.SwapState_SERVER_ERROR)) + "') AND timeoutBlockHeight <= " + strconv.FormatUint(uint64(currentBlockHeight), 10))
 }
 
 func (database *Database) CreateSwap(swap Swap) error {

--- a/nursery/channel.go
+++ b/nursery/channel.go
@@ -107,7 +107,7 @@ func (nursery *Nursery) updateChannelCreationStatus(channelCreation *database.Ch
 	}
 }
 
-func calculateChannelCreationCapacity(invoiceAmount float64, inboundLiquidity int) int64 {
+func calculateChannelCreationCapacity(invoiceAmount float64, inboundLiquidity uint32) int64 {
 	capacity := invoiceAmount / (1 - (float64(inboundLiquidity) / 100))
 	return int64(math.Floor(capacity))
 }

--- a/nursery/swap.go
+++ b/nursery/swap.go
@@ -299,7 +299,7 @@ func (nursery *Nursery) handleSwapStatus(swap *database.Swap, channelCreation *d
 			return
 		}
 
-		logger.Info("Found output for Swap " + swap.Id + " of " + strconv.Itoa(swapRates.OnchainAmount) + " satoshis")
+		logger.Info("Found output for Swap " + swap.Id + " of " + strconv.FormatUint(swapRates.OnchainAmount, 10) + " satoshis")
 
 		lndInfo, err := nursery.lnd.GetInfo()
 
@@ -320,7 +320,7 @@ func (nursery *Nursery) handleSwapStatus(swap *database.Swap, channelCreation *d
 			return
 		}
 
-		logger.Info("Generated new invoice for Swap " + swap.Id + " for " + strconv.Itoa(swapRates.SubmarineSwap.InvoiceAmount) + " satoshis")
+		logger.Info("Generated new invoice for Swap " + swap.Id + " for " + strconv.FormatUint(swapRates.SubmarineSwap.InvoiceAmount, 10) + " satoshis")
 
 		_, err = nursery.boltz.SetInvoice(boltz.SetInvoiceRequest{
 			Id:      swap.Id,
@@ -413,7 +413,7 @@ func (nursery *Nursery) handleSwapStatus(swap *database.Swap, channelCreation *d
 		}
 
 		if invoiceInfo.State != lnrpc.Invoice_SETTLED {
-			logger.Warning(swapType + " " + swap.Id + " was not actually settled. Refunding at block " + strconv.Itoa(swap.TimoutBlockHeight))
+			logger.Warning(swapType + " " + swap.Id + " was not actually settled. Refunding at block " + strconv.FormatUint(uint64(swap.TimoutBlockHeight), 10))
 			return
 		}
 
@@ -439,7 +439,7 @@ func (nursery *Nursery) handleSwapStatus(swap *database.Swap, channelCreation *d
 	}
 }
 
-func parseChannelPoint(channelPoint string) (string, int, error) {
+func parseChannelPoint(channelPoint string) (string, uint32, error) {
 	split := strings.Split(channelPoint, ":")
 	vout, err := strconv.Atoi(split[1])
 
@@ -447,7 +447,7 @@ func parseChannelPoint(channelPoint string) (string, int, error) {
 		return "", 0, err
 	}
 
-	return split[0], vout, nil
+	return split[0], uint32(vout), nil
 }
 
 func getSwapType(isChannelCreation bool) string {

--- a/rpcserver/router.go
+++ b/rpcserver/router.go
@@ -258,7 +258,7 @@ func (server *routedBoltzServer) Deposit(_ context.Context, request *boltzrpc.De
 func (server *routedBoltzServer) CreateSwap(_ context.Context, request *boltzrpc.CreateSwapRequest) (*boltzrpc.CreateSwapResponse, error) {
 	logger.Info("Creating Swap for " + strconv.FormatInt(request.Amount, 10) + " satoshis")
 
-	invoice, err := server.lnd.AddInvoice(request.Amount, nil, 0, utils.GetSwapMemo(server.symbol))
+	invoice, err := server.lnd.AddInvoice(int64(request.Amount), nil, 0, utils.GetSwapMemo(server.symbol))
 
 	if err != nil {
 		return nil, handleError(err)
@@ -355,7 +355,7 @@ func (server *routedBoltzServer) CreateChannel(_ context.Context, request *boltz
 
 	invoice, err := server.lnd.AddHoldInvoice(
 		preimageHash,
-		request.Amount,
+		int64(request.Amount),
 		// TODO: query timeout block delta from API
 		utils.CalculateInvoiceExpiry(144, utils.GetBlockTime(server.symbol)),
 		"Channel Creation from "+server.symbol,
@@ -415,7 +415,7 @@ func (server *routedBoltzServer) CreateChannel(_ context.Context, request *boltz
 	channelCreation := database.ChannelCreation{
 		SwapId:                 response.Id,
 		Status:                 boltz.ChannelNone,
-		InboundLiquidity:       int(inboundLiquidity),
+		InboundLiquidity:       inboundLiquidity,
 		Private:                request.Private,
 		FundingTransactionId:   "",
 		FundingTransactionVout: 0,
@@ -499,7 +499,7 @@ func (server *routedBoltzServer) CreateReverseSwap(_ context.Context, request *b
 		Type:           "reverseSubmarine",
 		PairId:         server.symbol + "/" + server.symbol,
 		OrderSide:      "buy",
-		InvoiceAmount:  int(request.Amount),
+		InvoiceAmount:  uint64(request.Amount),
 		PreimageHash:   hex.EncodeToString(preimageHash),
 		ClaimPublicKey: hex.EncodeToString(publicKey.SerializeCompressed()),
 	})

--- a/rpcserver/serializer.go
+++ b/rpcserver/serializer.go
@@ -19,7 +19,7 @@ func serializeSwap(swap *database.Swap) *boltzrpc.SwapInfo {
 		Invoice:             serializedSwap.Invoice,
 		LockupAddress:       serializedSwap.Address,
 		ExpectedAmount:      int64(serializedSwap.ExpectedAmount),
-		TimeoutBlockHeight:  uint32(serializedSwap.TimeoutBlockHeight),
+		TimeoutBlockHeight:  serializedSwap.TimeoutBlockHeight,
 		LockupTransactionId: serializedSwap.LockupTransactionId,
 		RefundTransactionId: serializedSwap.RefundTransactionId,
 	}
@@ -31,10 +31,10 @@ func serializeChannelCreation(channelCreation *database.ChannelCreation) *boltzr
 	return &boltzrpc.ChannelCreationInfo{
 		SwapId:                 serializedChannelCreation.SwapId,
 		Status:                 serializedChannelCreation.Status,
-		InboundLiquidity:       uint32(serializedChannelCreation.InboundLiquidity),
+		InboundLiquidity:       serializedChannelCreation.InboundLiquidity,
 		Private:                serializedChannelCreation.Private,
 		FundingTransactionId:   serializedChannelCreation.FundingTransactionId,
-		FundingTransactionVout: uint32(serializedChannelCreation.FundingTransactionVout),
+		FundingTransactionVout: serializedChannelCreation.FundingTransactionVout,
 	}
 }
 
@@ -52,7 +52,7 @@ func serializeReverseSwap(reverseSwap *database.ReverseSwap) *boltzrpc.ReverseSw
 		Invoice:             serializedReverseSwap.Invoice,
 		ClaimAddress:        serializedReverseSwap.ClaimAddress,
 		OnchainAmount:       int64(serializedReverseSwap.OnchainAmount),
-		TimeoutBlockHeight:  uint32(serializedReverseSwap.TimeoutBlockHeight),
+		TimeoutBlockHeight:  serializedReverseSwap.TimeoutBlockHeight,
 		LockupTransactionId: serializedReverseSwap.LockupTransactionId,
 		ClaimTransactionId:  serializedReverseSwap.ClaimTransactionId,
 	}


### PR DESCRIPTION
Because the `int` data type of Golang is either `int32` or `int64` depending on the architecture of the OS, the `/getpairs` request can fail on 32 bit operating systems because an overflow

This PR gets rid of the ambiguous `int` data type in the logic that interacts with the Boltz API to avoid that problem

Closes #40 

Thank you @brandonshope for finding this issue