### PR TITLE
Fix claimTransactionId typo

### DIFF
--- a/database/reverse.go
+++ b/database/reverse.go
@@ -4,10 +4,11 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"errors"
+	"strconv"
+
 	"github.com/BoltzExchange/boltz-lnd/boltz"
 	"github.com/BoltzExchange/boltz-lnd/boltzrpc"
 	"github.com/btcsuite/btcd/btcec"
-	"strconv"
 )
 
 type ReverseSwap struct {
@@ -87,7 +88,7 @@ func parseReverseSwap(rows *sql.Rows) (*ReverseSwap, error) {
 			"expectedAmount":      &reverseSwap.OnchainAmount,
 			"timeoutBlockheight":  &reverseSwap.TimeoutBlockHeight,
 			"lockupTransactionId": &reverseSwap.LockupTransactionId,
-			"claimTransactionId":  &reverseSwap.ClaimAddress,
+			"claimTransactionId":  &reverseSwap.ClaimTransactionId,
 		},
 	)
 


### PR DESCRIPTION
So today I couldn't finish a reverse swap with Boltz due to a weird error: `Could not decode claim address of Reverse Swap: decoded address is of unknown format`. Debugging with the almighty `log.Printf` revealed that the claim address is actually empty! But it was present in the database as I found using `sqlite3`. After about an hour of searching for clues I accidentally noticed that a particular field is used twice for different SQL columns. I have no idea how it worked before and why it stopped today (I used the same binary a couple of days ago), maybe the column order returned by SQLite was different so the `claimAddress` was put after `claimTransactionId` (which is of course empty before we sweep the funds!).

Anyway, now it's fixed. Hopefully, Boltz will see less failed swaps now, every such swap costs them on-chain fees and on Lightning cancellation is 100% free.