### PR TITLE
Build docker image for amd64, arm64, and arm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ RUN apk add --no-cache --update alpine-sdk \
     make \
     gcc
 
-# Checkout project.
-RUN git clone https://github.com/BoltzExchange/boltz-lnd /go/src/github.com/BoltzExchange/boltz-lnd
+# Shallow clone project.
+RUN git clone --depth=1 https://github.com/BoltzExchange/boltz-lnd /go/src/github.com/BoltzExchange/boltz-lnd
 
 # Build the binaries.
 RUN cd /go/src/github.com/BoltzExchange/boltz-lnd \

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,6 @@ changelog:
 
 docker:
 	@$(call print, "Building docker image")
-	docker build -t boltz/boltz-lnd:$(version) .
+	buildx build --platform linux/amd64 --platform linux/arm64 --platform linux/arm/v7 -t boltz/boltz-lnd:$(version) -t boltz/boltz-lnd:latest .
 
 .PHONY: build binaries

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,6 @@ changelog:
 
 docker:
 	@$(call print, "Building docker image")
-	buildx build --platform linux/amd64 --platform linux/arm64 --platform linux/arm/v7 -t boltz/boltz-lnd:$(version) -t boltz/boltz-lnd:latest .
+	docker buildx build --platform linux/amd64 --platform linux/arm64 --platform linux/arm/v7 -t boltz/boltz-lnd:$(version) -t boltz/boltz-lnd:latest .
 
 .PHONY: build binaries


### PR DESCRIPTION
This will enable usage of the docker image on raspberry pi and Apple M1 platform

![image](https://user-images.githubusercontent.com/433270/145079740-451fd40b-16d1-4ad6-9c87-674d37e1817d.png)

See: https://hub.docker.com/r/aphex3k/boltz-lnd/tags